### PR TITLE
Detect and return errors from Open in case of malformed data

### DIFF
--- a/uenv/env_test.go
+++ b/uenv/env_test.go
@@ -123,6 +123,21 @@ func (u *uenvTestSuite) TestReadStopsAfterDoubleNull(c *C) {
 	c.Assert(env.String(), Equals, "foo=bar\n")
 }
 
+// ensure that the malformed data is not causing us to panic.
+func (u *uenvTestSuite) TestErrorOnMalformedData(c *C) {
+	mockData := []byte{
+		// foo
+		0x66, 0x6f, 0x6f,
+		// eof
+		0x00, 0x00,
+	}
+	u.makeUbootEnvFromData(c, mockData)
+
+	env, err := Open(u.envFile)
+	c.Assert(err, ErrorMatches, `cannot parse line "foo" as key=value pair`)
+	c.Assert(env, IsNil)
+}
+
 func (u *uenvTestSuite) TestReadEmptyFile(c *C) {
 	mockData := []byte{
 		// eof


### PR DESCRIPTION
The Open code relied on parseData which would panic if the data did
not conform to the key=value syntax. Since panicking is may not be
expected by the caller return an error instead.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>