### PR TITLE
Added arch AMD & PPC64LE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+arch:
+ - amd64
+ - ppc64le
+ 
 language: go
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ arch:
  - amd64
  - ppc64le
  
+ 
 language: go
 
 install:


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/uboot-go/builds/190205340

Please have a look.

Regards,
Manish Kumar